### PR TITLE
(auth) 인증 가드 및 내 정보 조회 기능 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -23,7 +23,7 @@ export class AuthController {
     return {
       success: 'true',
       message: '로그인에 성공했습니다.',
-      token,
+      accessToken: token,
     };
   }
 }

--- a/src/auth/dto/sign-up.dto.ts
+++ b/src/auth/dto/sign-up.dto.ts
@@ -6,9 +6,9 @@ import {
   MinLength,
 } from 'class-validator';
 
-enum Role {
-  'admin',
-  'customer',
+export enum Role {
+  admin,
+  customer,
 }
 
 export class SignUpDto {

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -9,8 +9,8 @@ import {
 } from 'typeorm';
 
 export enum Role {
-  'admin',
-  'customer',
+  admin,
+  customer,
 }
 @Entity()
 export class User {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,34 +1,25 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+} from '@nestjs/common';
 import { UsersService } from './users.service';
-import { CreateUserDto } from './dto/create-user.dto';
-import { UpdateUserDto } from './dto/update-user.dto';
+import { AuthGuard } from '@nestjs/passport';
+import { UserInfo } from 'src/utils/userInfo.decorator';
+import { User } from './entities/user.entity';
 
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-  @Post()
-  create(@Body() createUserDto: CreateUserDto) {
-    return this.usersService.create(createUserDto);
-  }
-
-  @Get()
-  findAll() {
-    return this.usersService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.usersService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
-    return this.usersService.update(+id, updateUserDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.usersService.remove(+id);
+  /* 내 정보 조회하기 */
+  @UseGuards(AuthGuard('jwt'))
+  @Get('me')
+  async findMyInfoByMyId(@UserInfo() user: User) {
+    return await this.usersService.findOneById(user.id);
   }
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { JwtService } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
 
 @Module({
   controllers: [UsersController],
-  providers: [UsersService],
+  providers: [UsersService, JwtService],
+  imports: [TypeOrmModule.forFeature([User])],
 })
 export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,26 +1,18 @@
 import { Injectable } from '@nestjs/common';
-import { CreateUserDto } from './dto/create-user.dto';
-import { UpdateUserDto } from './dto/update-user.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { JwtService } from '@nestjs/jwt';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class UsersService {
-  create(createUserDto: CreateUserDto) {
-    return 'This action adds a new user';
-  }
+  constructor(
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+    private readonly jwtService: JwtService,
+  ) {}
 
-  findAll() {
-    return `This action returns all users`;
-  }
-
-  findOne(id: number) {
-    return `This action returns a #${id} user`;
-  }
-
-  update(id: number, updateUserDto: UpdateUserDto) {
-    return `This action updates a #${id} user`;
-  }
-
-  remove(id: number) {
-    return `This action removes a #${id} user`;
+  async findOneById(id: number) {
+    return await this.userRepository.findOneBy({ id });
   }
 }

--- a/src/utils/payload.ts
+++ b/src/utils/payload.ts
@@ -1,0 +1,9 @@
+import { Role } from 'src/users/entities/user.entity';
+
+export interface Payload {
+  id: number;
+  name: string;
+  email: string;
+  point: number;
+  role: Role;
+}

--- a/src/utils/userInfo.decorator.ts
+++ b/src/utils/userInfo.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const UserInfo = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    // console.log('request: ', request); // 먼가 많은 req 정보들이 나오지만 user 정보도 나옴 근데.. password 도 나옴.
+    return request.user ? request.user : null;
+  },
+);


### PR DESCRIPTION
#2 

1) 인증 가드 
- Passport 전략 중 jwt 전략 사용

2) 내 정보 조회 기능
- 로그인 시에만 가능 (req.header에 Bearer 토큰 필요)

**특이사항**
1) 내 정보 조회 시 role이 숫자로 나오는 현상
- Enum 설정이 잘못되었음
-> 기존 '' 로 문자열 취급하였으나 문자열 취급하지 않고 그대로 사용
=> 내가 원하는 admin, customer 잘 나옴

2) UserInfo 커스텀 데코레이터 생성
- 여기서 req에 접근하여 req.user를 확인할 수 있는데 password를 같이 가져와서 보안 상 문제가 있어보임 !! 
- Payload에 유저 정보를 담아둔게 있는데 그걸 사용할 수 없을지 고민 필요