### PR TITLE
(performance/create) 공연 등록 기능 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { User } from './users/entities/user.entity';
+import { Performance } from './performances/entities/performance.entity';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { PerformancesModule } from './performances/performances.module';
@@ -21,7 +22,7 @@ const typeOrmModuleOptions = {
     username: configService.get('DB_USERNAME'),
     password: configService.get('DB_PASSWORD'),
     database: configService.get('DB_NAME'),
-    entities: [User],
+    entities: [User, Performance],
     synchronize: configService.get('DB_SYNC'),
     logging: true,
   }),

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppService } from './app.service';
 import { User } from './users/entities/user.entity';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
+import { PerformancesModule } from './performances/performances.module';
 
 const typeOrmModuleOptions = {
   useFactory: async (
@@ -43,6 +44,7 @@ const typeOrmModuleOptions = {
     TypeOrmModule.forRootAsync(typeOrmModuleOptions),
     AuthModule,
     UsersModule,
+    PerformancesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/dto/sign-up.dto.ts
+++ b/src/auth/dto/sign-up.dto.ts
@@ -7,8 +7,8 @@ import {
 } from 'class-validator';
 
 export enum Role {
-  admin,
-  customer,
+  Admin = 'Admin',
+  Customer = 'Customer',
 }
 
 export class SignUpDto {

--- a/src/auth/guard/roles.guard.ts
+++ b/src/auth/guard/roles.guard.ts
@@ -1,0 +1,33 @@
+import { Role } from '../../users/entities/user.entity';
+
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class RolesGuard extends AuthGuard('jwt') implements CanActivate {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  async canActivate(context: ExecutionContext) {
+    const authenticated = await super.canActivate(context);
+    if (!authenticated) {
+      return false;
+    }
+
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>('roles', [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.some((role) => {
+      return user.role === role;
+    });
+  }
+}

--- a/src/performances/dto/create-performance.dto.ts
+++ b/src/performances/dto/create-performance.dto.ts
@@ -1,0 +1,23 @@
+import { IsDate, IsNotEmpty, IsString } from 'class-validator';
+
+export class CreatePerformanceDto {
+  @IsString()
+  @IsNotEmpty({ message: '타이틀을 입력해주세요.' })
+  readonly title: string;
+
+  @IsDate()
+  @IsNotEmpty({ message: '시작 시간을 입력해주세요' })
+  readonly startTime: Date;
+
+  @IsDate()
+  @IsNotEmpty({ message: '종료 시간을 입력해주세요' })
+  readonly endTime: Date;
+
+  @IsString({ each: true })
+  @IsNotEmpty()
+  readonly genres: string[];
+
+  @IsString()
+  @IsNotEmpty()
+  readonly overView: string;
+}

--- a/src/performances/dto/create-performance.dto.ts
+++ b/src/performances/dto/create-performance.dto.ts
@@ -1,15 +1,15 @@
-import { IsDate, IsNotEmpty, IsString } from 'class-validator';
+import { IsDate, IsDateString, IsNotEmpty, IsString } from 'class-validator';
 
 export class CreatePerformanceDto {
   @IsString()
   @IsNotEmpty({ message: '타이틀을 입력해주세요.' })
   readonly title: string;
 
-  @IsDate()
+  @IsDateString()
   @IsNotEmpty({ message: '시작 시간을 입력해주세요' })
   readonly startTime: Date;
 
-  @IsDate()
+  @IsDateString()
   @IsNotEmpty({ message: '종료 시간을 입력해주세요' })
   readonly endTime: Date;
 

--- a/src/performances/dto/update-performance.dto.ts
+++ b/src/performances/dto/update-performance.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePerformanceDto } from './create-performance.dto';
+
+export class UpdatePerformanceDto extends PartialType(CreatePerformanceDto) {}

--- a/src/performances/entities/performance.entity.ts
+++ b/src/performances/entities/performance.entity.ts
@@ -1,0 +1,42 @@
+import { IsDate, IsString } from 'class-validator';
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export class Performance {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @IsString()
+  @Column('varchar', { length: 100, nullable: false })
+  title: string;
+
+  @IsDate()
+  @Column('datetime', { nullable: false })
+  startTime: Date;
+
+  @IsDate()
+  @Column('datetime', { nullable: false })
+  endTime: Date;
+
+  @IsString({ each: true })
+  @Column('simple-array', { nullable: false })
+  genres: string[];
+
+  @IsString()
+  @Column('varchar', { length: 255, nullable: false })
+  overView: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn({ default: null })
+  updatedAt?: Date;
+
+  @DeleteDateColumn({ default: null })
+  deletedAt?: Date;
+}

--- a/src/performances/entities/performance.entity.ts
+++ b/src/performances/entities/performance.entity.ts
@@ -1,12 +1,17 @@
-import { IsDate, IsString } from 'class-validator';
+import { IsDate, IsString, IsNumber } from 'class-validator';
+import { User } from 'src/users/entities/user.entity';
 import {
   Column,
   CreateDateColumn,
   DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 
+@Entity()
 export class Performance {
   @PrimaryGeneratedColumn()
   id: number;
@@ -30,6 +35,14 @@ export class Performance {
   @IsString()
   @Column('varchar', { length: 255, nullable: false })
   overView: string;
+
+  @ManyToOne(() => User, (user) => user.performance, {
+    onDelete: 'CASCADE',
+  })
+  user: User;
+
+  @Column('int')
+  userId: number;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/performances/performances.controller.spec.ts
+++ b/src/performances/performances.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PerformancesController } from './performances.controller';
+import { PerformancesService } from './performances.service';
+
+describe('PerformancesController', () => {
+  let controller: PerformancesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PerformancesController],
+      providers: [PerformancesService],
+    }).compile();
+
+    controller = module.get<PerformancesController>(PerformancesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/performances/performances.controller.ts
+++ b/src/performances/performances.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { PerformancesService } from './performances.service';
+import { CreatePerformanceDto } from './dto/create-performance.dto';
+import { UpdatePerformanceDto } from './dto/update-performance.dto';
+
+@Controller('performances')
+export class PerformancesController {
+  constructor(private readonly performancesService: PerformancesService) {}
+
+  @Post()
+  create(@Body() createPerformanceDto: CreatePerformanceDto) {
+    return this.performancesService.create(createPerformanceDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.performancesService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.performancesService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updatePerformanceDto: UpdatePerformanceDto) {
+    return this.performancesService.update(+id, updatePerformanceDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.performancesService.remove(+id);
+  }
+}

--- a/src/performances/performances.controller.ts
+++ b/src/performances/performances.controller.ts
@@ -1,15 +1,37 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+} from '@nestjs/common';
 import { PerformancesService } from './performances.service';
 import { CreatePerformanceDto } from './dto/create-performance.dto';
 import { UpdatePerformanceDto } from './dto/update-performance.dto';
+
+import { Roles } from 'src/utils/role.decorator';
+import { Role, User } from 'src/users/entities/user.entity';
+import { RolesGuard } from 'src/auth/guard/roles.guard';
+import { UserInfo } from 'src/utils/userInfo.decorator';
 
 @Controller('performances')
 export class PerformancesController {
   constructor(private readonly performancesService: PerformancesService) {}
 
+  @UseGuards(RolesGuard)
+  @Roles(Role.Admin)
   @Post()
-  create(@Body() createPerformanceDto: CreatePerformanceDto) {
-    return this.performancesService.create(createPerformanceDto);
+  create(
+    @Body() createPerformanceDto: CreatePerformanceDto,
+    @UserInfo() user: User,
+  ) {
+    return {
+      success: 'true',
+      message: this.performancesService.create(createPerformanceDto, user.id),
+    };
   }
 
   @Get()
@@ -22,11 +44,16 @@ export class PerformancesController {
     return this.performancesService.findOne(+id);
   }
 
+  @UseGuards(RolesGuard)
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updatePerformanceDto: UpdatePerformanceDto) {
+  update(
+    @Param('id') id: string,
+    @Body() updatePerformanceDto: UpdatePerformanceDto,
+  ) {
     return this.performancesService.update(+id, updatePerformanceDto);
   }
 
+  @UseGuards(RolesGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.performancesService.remove(+id);

--- a/src/performances/performances.module.ts
+++ b/src/performances/performances.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PerformancesService } from './performances.service';
+import { PerformancesController } from './performances.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Performance } from './entities/performance.entity';
+
+@Module({
+  controllers: [PerformancesController],
+  providers: [PerformancesService],
+  imports: [TypeOrmModule.forFeature([Performance])],
+})
+export class PerformancesModule {}

--- a/src/performances/performances.service.spec.ts
+++ b/src/performances/performances.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PerformancesService } from './performances.service';
+
+describe('PerformancesService', () => {
+  let service: PerformancesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PerformancesService],
+    }).compile();
+
+    service = module.get<PerformancesService>(PerformancesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/performances/performances.service.ts
+++ b/src/performances/performances.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreatePerformanceDto } from './dto/create-performance.dto';
+import { UpdatePerformanceDto } from './dto/update-performance.dto';
+
+@Injectable()
+export class PerformancesService {
+  create(createPerformanceDto: CreatePerformanceDto) {
+    return 'This action adds a new performance';
+  }
+
+  findAll() {
+    return `This action returns all performances`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} performance`;
+  }
+
+  update(id: number, updatePerformanceDto: UpdatePerformanceDto) {
+    return `This action updates a #${id} performance`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} performance`;
+  }
+}

--- a/src/performances/performances.service.ts
+++ b/src/performances/performances.service.ts
@@ -1,11 +1,31 @@
 import { Injectable } from '@nestjs/common';
 import { CreatePerformanceDto } from './dto/create-performance.dto';
 import { UpdatePerformanceDto } from './dto/update-performance.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Performance } from './entities/performance.entity';
 
 @Injectable()
 export class PerformancesService {
-  create(createPerformanceDto: CreatePerformanceDto) {
-    return 'This action adds a new performance';
+  constructor(
+    @InjectRepository(Performance)
+    private readonly performanceRepository: Repository<Performance>,
+  ) {}
+
+  async create(createPerformanceDto: CreatePerformanceDto, userId: number) {
+    const { title, startTime, endTime, genres, overView } =
+      createPerformanceDto;
+
+    await this.performanceRepository.save({
+      title,
+      startTime,
+      endTime,
+      genres,
+      overView,
+      userId,
+    });
+
+    return '공연 등록이 완료되었습니다.';
   }
 
   findAll() {

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -37,15 +37,12 @@ export class User {
   @Column('varchar', { nullable: false })
   role: Role;
 
-  @IsDate()
   @CreateDateColumn()
   createdAt: Date;
 
-  @IsDate()
   @UpdateDateColumn({ default: null })
   updatedAt: Date;
 
-  @IsDate()
   @DeleteDateColumn({ default: null })
   deletedAt: Date;
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -4,13 +4,15 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { Performance } from 'src/performances/entities/performance.entity';
 
 export enum Role {
-  admin,
-  customer,
+  Admin = 'Admin',
+  Customer = 'Customer',
 }
 @Entity()
 export class User {
@@ -45,4 +47,7 @@ export class User {
 
   @DeleteDateColumn({ default: null })
   deletedAt: Date;
+
+  @OneToMany(() => Performance, (performance) => performance.user)
+  performance: Performance[];
 }

--- a/src/utils/role.decorator.ts
+++ b/src/utils/role.decorator.ts
@@ -1,0 +1,5 @@
+import { Role } from '../users/entities/user.entity';
+
+import { SetMetadata } from '@nestjs/common';
+
+export const Roles = (...roles: Role[]) => SetMetadata('roles', roles);


### PR DESCRIPTION
#6 

 **진행사항** 
1. performance 리소스 생성 및 초기 세팅 
- typeORM으로 레포지토리 연결
- Entity 파일 및 DTO 파일 생성
- User 테이블과 관계 설정 (user:performance = 1:N)
- app.module.ts 내 entities에 Performance 추가

2.  Role 가드 생성
- 역할에 따라 인가해주는 가드 파일 생성 
- 가드 시 사용할 role.decorator.ts 파일 생성


 **특이사항** 
1. roles.guard.ts에서 검증 시 role 값이 다르게 나오는 경우 !
`const { user } = context.switchToHttp().getRequest();
 return requiredRoles.some((role) => {
 return user.role === role;`
 요기서 user.role은 Admin이 잘 나오고 role은 0이 나와서 계속 권한이 없다고 나왔음 ! 

> Enum 설정 시 명시적인 값을 설정 안해서 그런듯 한데 왜 숫자가 나오는지는 아직도 의문 
> 해결은 아래와 같이 코드를 수정하여 해결함 
`export enum Role {
  Admin = 'Admin',
  Customer = 'Customer',
}`
