### PR TITLE
(performance/read) 공연 조회 기능 추가

### DIFF
--- a/api-docs/performance.http
+++ b/api-docs/performance.http
@@ -29,3 +29,6 @@ GET http://localhost:3000/performances
 
 ### 특정 공연 조회하기(id)
 GET http://localhost:3000/performances/2
+
+### 특정 공연 조회하기(Keyword)
+GET http://localhost:3000/performances/search/?keyword=y

--- a/api-docs/performance.http
+++ b/api-docs/performance.http
@@ -1,0 +1,25 @@
+@token = {{login.response.body.$.accessToken}}
+
+### 로그인
+# @name login
+POST http://localhost:3000/sign-in
+Content-Type: application/json
+
+{
+	"password" : "123456",
+	"email" : "admin1@test.com"
+}
+
+
+### 공연 등록하기
+POST http://localhost:3000/performances
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "title": "Your Title",
+  "startTime": "2023-12-31 11:00",
+  "endTime": "2023-12-31 14:00",
+  "genres": ["Genre1", "Genre2"],
+  "overView": "Your Overview"
+}

--- a/api-docs/performance.http
+++ b/api-docs/performance.http
@@ -23,3 +23,9 @@ Authorization: Bearer {{token}}
   "genres": ["Genre1", "Genre2"],
   "overView": "Your Overview"
 }
+
+### 모든 공연 조회하기
+GET http://localhost:3000/performances
+
+### 특정 공연 조회하기(id)
+GET http://localhost:3000/performances/2

--- a/src/performances/performances.controller.ts
+++ b/src/performances/performances.controller.ts
@@ -11,6 +11,7 @@ import {
 import { PerformancesService } from './performances.service';
 import { CreatePerformanceDto } from './dto/create-performance.dto';
 import { UpdatePerformanceDto } from './dto/update-performance.dto';
+import { Performance } from './entities/performance.entity';
 
 import { Roles } from 'src/utils/role.decorator';
 import { Role, User } from 'src/users/entities/user.entity';
@@ -21,24 +22,30 @@ import { UserInfo } from 'src/utils/userInfo.decorator';
 export class PerformancesController {
   constructor(private readonly performancesService: PerformancesService) {}
 
+  /* 공연 등록 */
   @UseGuards(RolesGuard)
   @Roles(Role.Admin)
   @Post()
-  create(
+  async create(
     @Body() createPerformanceDto: CreatePerformanceDto,
     @UserInfo() user: User,
   ) {
+    await this.performancesService.create(createPerformanceDto, user.id);
     return {
       success: 'true',
-      message: this.performancesService.create(createPerformanceDto, user.id),
+      message: '공연 등록에 성공했습니다.',
     };
   }
 
+  /* 모든 공연 가져오기 */
   @Get()
-  findAll() {
-    return this.performancesService.findAll();
+  async findAll(): Promise<Performance[]> {
+    const performances: Performance[] =
+      await this.performancesService.findAll();
+    return performances;
   }
 
+  /* 특정 공연 가져오기 (id) */
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.performancesService.findOne(+id);

--- a/src/performances/performances.controller.ts
+++ b/src/performances/performances.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Delete,
   UseGuards,
+  Query,
 } from '@nestjs/common';
 import { PerformancesService } from './performances.service';
 import { CreatePerformanceDto } from './dto/create-performance.dto';
@@ -39,18 +40,41 @@ export class PerformancesController {
 
   /* 모든 공연 가져오기 */
   @Get()
-  async findAll(): Promise<Performance[]> {
+  async findAll() {
     const performances: Performance[] =
       await this.performancesService.findAll();
-    return performances;
+    return {
+      success: 'true',
+      message: '공연 조회에 성공했습니다.',
+      data: performances,
+    };
+  }
+
+  /* 특정 공연 가져오기 'Keyword') */
+  @Get('search')
+  async findByKeyword(@Query('keyword') keyword: string) {
+    console.log('keyword: ', keyword);
+    const performances: Performance[] =
+      await this.performancesService.findByKeyword(keyword);
+
+    return {
+      success: 'true',
+      message: '공연 조회에 성공했습니다.',
+      data: performances,
+    };
   }
 
   /* 특정 공연 가져오기 (id) */
   @Get(':id')
-  async findOne(@Param('id') id: number) {
-    const performance: Performance = await this.performancesService.findOne(id);
+  async findOneById(@Param('id') id: number) {
+    const performance: Performance =
+      await this.performancesService.findOneById(id);
 
-    return performance;
+    return {
+      success: 'true',
+      message: '공연 조회에 성공했습니다.',
+      data: performance,
+    };
   }
 
   @UseGuards(RolesGuard)

--- a/src/performances/performances.controller.ts
+++ b/src/performances/performances.controller.ts
@@ -47,8 +47,10 @@ export class PerformancesController {
 
   /* 특정 공연 가져오기 (id) */
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.performancesService.findOne(+id);
+  async findOne(@Param('id') id: number) {
+    const performance: Performance = await this.performancesService.findOne(id);
+
+    return performance;
   }
 
   @UseGuards(RolesGuard)

--- a/src/performances/performances.service.ts
+++ b/src/performances/performances.service.ts
@@ -28,8 +28,10 @@ export class PerformancesService {
     return '공연 등록이 완료되었습니다.';
   }
 
-  findAll() {
-    return `This action returns all performances`;
+  async findAll(): Promise<Performance[]> {
+    const performances: Performance[] = await this.performanceRepository.find();
+
+    return performances;
   }
 
   findOne(id: number) {

--- a/src/performances/performances.service.ts
+++ b/src/performances/performances.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreatePerformanceDto } from './dto/create-performance.dto';
 import { UpdatePerformanceDto } from './dto/update-performance.dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Like, Repository } from 'typeorm';
 import { Performance } from './entities/performance.entity';
 
 @Injectable()
@@ -34,7 +34,7 @@ export class PerformancesService {
     return performances;
   }
 
-  async findOne(id: number) {
+  async findOneById(id: number) {
     const performance: Performance = await this.performanceRepository.findOne({
       where: { id },
     });
@@ -44,6 +44,17 @@ export class PerformancesService {
     }
 
     return performance;
+  }
+
+  async findByKeyword(keyword: string) {
+    console.log('keyword 어떻게 나와', keyword);
+    const performances: Performance[] = await this.performanceRepository.find({
+      where: {
+        title: Like(`%${keyword}%`),
+      },
+    });
+
+    return performances;
   }
 
   update(id: number, updatePerformanceDto: UpdatePerformanceDto) {

--- a/src/performances/performances.service.ts
+++ b/src/performances/performances.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreatePerformanceDto } from './dto/create-performance.dto';
 import { UpdatePerformanceDto } from './dto/update-performance.dto';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -34,8 +34,16 @@ export class PerformancesService {
     return performances;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} performance`;
+  async findOne(id: number) {
+    const performance: Performance = await this.performanceRepository.findOne({
+      where: { id },
+    });
+
+    if (!performance) {
+      throw new NotFoundException('해당하는 공연을 찾을 수 없습니다.');
+    }
+
+    return performance;
   }
 
   update(id: number, updatePerformanceDto: UpdatePerformanceDto) {


### PR DESCRIPTION
#6 

 **진행사항** 
1. 공연 조회 기능 추가
- 모든 공연 조회 
- 특정 공연 조회 (id)
- 특정 공연 조회 (keyword) 

2. 테스트 프로그램 REST Client로 변경
- 로그인 시 토큰 값 자동으로 할당 가능
- 다른 프로그램으로 이동 안하고 VS코드 자체에서 사용 가능


 **특이사항** 
1. 컨트롤러에서 키워드가 id 보다 밑에 있으면 인식이 안됨 !
- Id 로 조회하는 부분은 Params 에서 :id 가 변수인 부분임으로 예상하지 않은 변수가 들어가서 id 컬럼에서 이상한 값으로 조회하게 됨
- 따라서 키워드 검색 부분을 id 보다 위로 올려서 해결 !
- 키워드 검색 시 검색 값이 없을 경우 에러처리 안하고 빈 배열 응답