### PR TITLE
(performance/update) 공연 수정 기능 API 추가

### DIFF
--- a/api-docs/performance.http
+++ b/api-docs/performance.http
@@ -1,6 +1,28 @@
 @token = {{login.response.body.$.accessToken}}
 
-### 로그인
+### 회원가입
+POST http://localhost:3000/sign-up
+Content-Type: application/json
+
+{
+	"password" : "123456",
+	"confirmPassword" : "123456",
+	"name" : "문준식2",
+	"role" : "Admin",
+	"email" : "admin2@test.com"
+}
+
+### 로그인 (일반 유저)
+# @name login
+POST http://localhost:3000/sign-in
+Content-Type: application/json
+
+{
+	"password" : "123456",
+	"email" : "customer1@test.com"
+}
+
+### 로그인 (어드민 유저)
 # @name login
 POST http://localhost:3000/sign-in
 Content-Type: application/json
@@ -28,7 +50,20 @@ Authorization: Bearer {{token}}
 GET http://localhost:3000/performances
 
 ### 특정 공연 조회하기(id)
-GET http://localhost:3000/performances/2
+GET http://localhost:3000/performances/4
 
 ### 특정 공연 조회하기(Keyword)
 GET http://localhost:3000/performances/search/?keyword=y
+
+### 공연 수정하기
+PATCH http://localhost:3000/performances/1
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "title": "hi",
+  "startTime": "2023-12-31 15:00",
+  "endTime": "2023-12-31 16:00",
+  "genres": ["Genre2", "Genre3"],
+  "overView": "Modify overview"
+}

--- a/src/performances/performances.controller.ts
+++ b/src/performances/performances.controller.ts
@@ -18,6 +18,7 @@ import { Roles } from 'src/utils/role.decorator';
 import { Role, User } from 'src/users/entities/user.entity';
 import { RolesGuard } from 'src/auth/guard/roles.guard';
 import { UserInfo } from 'src/utils/userInfo.decorator';
+import { userInfo } from 'os';
 
 @Controller('performances')
 export class PerformancesController {
@@ -53,7 +54,6 @@ export class PerformancesController {
   /* 특정 공연 가져오기 'Keyword') */
   @Get('search')
   async findByKeyword(@Query('keyword') keyword: string) {
-    console.log('keyword: ', keyword);
     const performances: Performance[] =
       await this.performancesService.findByKeyword(keyword);
 
@@ -77,13 +77,20 @@ export class PerformancesController {
     };
   }
 
+  /* 특정 공연 수정하기 */
   @UseGuards(RolesGuard)
   @Patch(':id')
-  update(
-    @Param('id') id: string,
+  async update(
+    @Param('id') id: number,
     @Body() updatePerformanceDto: UpdatePerformanceDto,
+    @UserInfo() user: User,
   ) {
-    return this.performancesService.update(+id, updatePerformanceDto);
+    await this.performancesService.update(id, updatePerformanceDto, user.id);
+
+    return {
+      success: 'true',
+      message: '공연 수정에 성공했습니다.',
+    };
   }
 
   @UseGuards(RolesGuard)

--- a/src/performances/performances.service.ts
+++ b/src/performances/performances.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { CreatePerformanceDto } from './dto/create-performance.dto';
 import { UpdatePerformanceDto } from './dto/update-performance.dto';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -47,7 +51,6 @@ export class PerformancesService {
   }
 
   async findByKeyword(keyword: string) {
-    console.log('keyword 어떻게 나와', keyword);
     const performances: Performance[] = await this.performanceRepository.find({
       where: {
         title: Like(`%${keyword}%`),
@@ -57,8 +60,23 @@ export class PerformancesService {
     return performances;
   }
 
-  update(id: number, updatePerformanceDto: UpdatePerformanceDto) {
-    return `This action updates a #${id} performance`;
+  async update(
+    id: number,
+    updatePerformanceDto: UpdatePerformanceDto,
+    userId: number,
+  ) {
+    const performance = await this.findOneById(id);
+
+    if (performance.userId !== userId) {
+      throw new UnauthorizedException('권한이 없습니다.');
+    }
+
+    const updatedPerformance = await this.performanceRepository.update(
+      { id },
+      updatePerformanceDto,
+    );
+
+    return updatedPerformance;
   }
 
   remove(id: number) {


### PR DESCRIPTION
#6 

**진행 사항**
1) 유저의 role이 admin인 경우에만 호출 가능
- RolesGuard 사용

2) 해당 공연을 등록한 사람만 수정이 가능하도록 제한
- controller 에서 UserInfo 데코레이터를 사용하여 user 정보 가져옴
- service 에서 user.id 와 공연의 userId 값이 같을 경우에만 수정이 가능하도록 유효성 검사 추가

**특이사항**
1) 업데이트 이후 반환 값은 업데이트 된 정보들이 나오는게 아니었음 
- 쿼리로 넣을 때와 마찬가지로 수정된 내용에 대한 정보?들만 나옴 
- 따라서 별도로 업데이트 된 공연 정보를 리턴하지 않음 (실제로도 사용을 안할 듯 보임)