### PR TITLE
(performance/delete) 공연 삭제 API 추가

### DIFF
--- a/api-docs/performance.http
+++ b/api-docs/performance.http
@@ -50,7 +50,7 @@ Authorization: Bearer {{token}}
 GET http://localhost:3000/performances
 
 ### 특정 공연 조회하기(id)
-GET http://localhost:3000/performances/4
+GET http://localhost:3000/performances/1
 
 ### 특정 공연 조회하기(Keyword)
 GET http://localhost:3000/performances/search/?keyword=y
@@ -67,3 +67,7 @@ Authorization: Bearer {{token}}
   "genres": ["Genre2", "Genre3"],
   "overView": "Modify overview"
 }
+
+### 공연 삭제하기
+DELETE http://localhost:3000/performances/6
+Authorization: Bearer {{token}}

--- a/src/performances/performances.controller.ts
+++ b/src/performances/performances.controller.ts
@@ -95,7 +95,11 @@ export class PerformancesController {
 
   @UseGuards(RolesGuard)
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.performancesService.remove(+id);
+  async remove(@Param('id') id: number, @UserInfo() user: User) {
+    await this.performancesService.remove(id, user.id);
+    return {
+      success: 'true',
+      message: '공연 삭제에 성공했습니다.',
+    };
   }
 }

--- a/src/performances/performances.service.ts
+++ b/src/performances/performances.service.ts
@@ -68,13 +68,18 @@ export class PerformancesService {
     const performance = await this.findOneById(id);
 
     if (performance.userId !== userId) {
-      throw new UnauthorizedException('권한이 없습니다.');
+      throw new UnauthorizedException('수정 권한이 없습니다.');
     }
 
     await this.performanceRepository.update({ id }, updatePerformanceDto);
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} performance`;
+  async remove(id: number, userId: number) {
+    const performance = await this.findOneById(id);
+    if (performance.userId !== userId) {
+      throw new UnauthorizedException('삭제 권한이 없습니다.');
+    }
+
+    await this.performanceRepository.softDelete({ id });
   }
 }


### PR DESCRIPTION
#6 

**진행사항**
**1) 삭제는 softDelete로 진행**
- DB에 데이터는 삭제되지 않고 deletedAt에 타임스탬프가 찍힘
- 조회 시 별도 설정을 하지 않아도 softDelete된 데이터는 안가져오는 것으로 확인

**특이사항**
**1) softDelete 된 값은 DB에 삭제되지 않고 남아있지만 조회 시에는 자동으로 제외됨**
- GET 메서드 즉 find 관련 메서드를 사용할 경우 별도로 옵션을 설정 `null이 아닌 데이터를 가져와라` 하지 않아도 그냥 가져와짐