### PR TITLE
(seats/read) 좌석 조회 API 추가

### DIFF
--- a/api-docs/seats.http
+++ b/api-docs/seats.http
@@ -44,3 +44,9 @@ Authorization: Bearer {{token}}
   "price": 50000,
   "status": "Possible"
 }
+
+### 특정 공연 모든 좌석 조회하기(performanceId)
+GET http://localhost:3000/seats/?performance=6
+
+### 특정 좌석 조회하기 (id)
+GET http://localhost:3000/seats/15

--- a/src/performances/performances.controller.ts
+++ b/src/performances/performances.controller.ts
@@ -18,7 +18,6 @@ import { Roles } from 'src/utils/role.decorator';
 import { Role, User } from 'src/users/entities/user.entity';
 import { RolesGuard } from 'src/auth/guard/roles.guard';
 import { UserInfo } from 'src/utils/userInfo.decorator';
-import { userInfo } from 'os';
 
 @Controller('performances')
 export class PerformancesController {

--- a/src/seats/seats.controller.ts
+++ b/src/seats/seats.controller.ts
@@ -18,11 +18,13 @@ import { RolesGuard } from 'src/auth/guard/roles.guard';
 import { Roles } from 'src/utils/role.decorator';
 import { Role } from 'src/users/entities/user.entity';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { Seat } from './entities/seat.entity';
 
 @Controller('seats')
 export class SeatsController {
   constructor(private readonly seatsService: SeatsService) {}
 
+  /* 좌석 1개씩 등록하기 */
   @UseGuards(RolesGuard)
   @Roles(Role.Admin)
   @Post(':performanceId')
@@ -38,6 +40,7 @@ export class SeatsController {
     };
   }
 
+  /* 좌석 CSV 로 등록하기 */
   @UseGuards(RolesGuard)
   @Roles(Role.Admin)
   @Post('file/:performanceId')
@@ -54,14 +57,26 @@ export class SeatsController {
     };
   }
 
+  /* 모든 좌석 조회하기 */
   @Get()
-  findAll() {
-    return this.seatsService.findAll();
+  async findAll(@Query('performance') performanceId: number) {
+    const seats: Seat[] = await this.seatsService.findAllSeats(performanceId);
+    return {
+      success: 'true',
+      message: '좌석 조회에 성공했습니다.',
+      data: seats,
+    };
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.seatsService.findOne(+id);
+  async findOne(@Param('id') id: number) {
+    const seat: Seat = await this.seatsService.findOne(id);
+
+    return {
+      success: 'true',
+      message: '좌석 조회에 성공했습니다.',
+      data: seat,
+    };
   }
 
   @Patch(':id')

--- a/src/seats/seats.service.ts
+++ b/src/seats/seats.service.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateSeatDto } from './dto/create-seat.dto';
 import { UpdateSeatDto } from './dto/update-seat.dto';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -98,12 +102,26 @@ export class SeatsService {
     await this.seatRepository.save(createSeatDto);
   }
 
-  findAll() {
-    return `This action returns all seats`;
+  async findAllSeats(performanceId: number) {
+    const performance =
+      await this.performanceService.findOneById(performanceId);
+
+    const seats: Seat[] = await this.seatRepository.find({
+      where: {
+        performanceId: performance.id,
+      },
+    });
+
+    return seats;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} seat`;
+  async findOne(id: number) {
+    const seat = await this.seatRepository.findOne({ where: { id } });
+
+    if (!seat) {
+      throw new NotFoundException('해당하는 좌석을 찾을 수 없습니다.');
+    }
+    return seat;
   }
 
   update(id: number, updateSeatDto: UpdateSeatDto) {


### PR DESCRIPTION
#13 
**진행사항**
**1) 모든 좌석 조회 기능(공연별)**
- 공연별로 모든 좌석 조회 기능 추가
- 공연이 없을 경우 에러 처리
- 좌석이 없을 경우 빈 배열 응답

**2) 특정 좌석 조회 기능(id)**
- 좌석 id 가 PK이기 때문에 별도 공연 ID 는 사용하지 않음
- 해당 좌석이 없을 경우 에러처리

**특이사항**
1) 해당 API 가 단독으로 호출될 일은 많이 없어보이긴 하나 만들어둠 