### PR TITLE
(reservation/create) 예약기능 추가

### DIFF
--- a/api-docs/performance.http
+++ b/api-docs/performance.http
@@ -56,12 +56,12 @@ GET http://localhost:3000/performances/1
 GET http://localhost:3000/performances/search/?keyword=y
 
 ### 공연 수정하기
-PATCH http://localhost:3000/performances/6
+PATCH http://localhost:3000/performances/3
 Content-Type: application/json
 Authorization: Bearer {{token}}
 
 {
-  "title": "hi",
+  "title": "예약 테스트 해봅니다 3번 공연",
   "startTime": "2023-12-31 15:00",
   "endTime": "2023-12-31 16:00",
   "genres": ["Genre2", "Genre3"],

--- a/api-docs/reservation.http
+++ b/api-docs/reservation.http
@@ -1,0 +1,57 @@
+@token = {{login.response.body.$.accessToken}}
+
+### 회원가입
+POST http://localhost:3000/sign-up
+Content-Type: application/json
+
+{
+	"password" : "123456",
+	"confirmPassword" : "123456",
+	"name" : "문준식2",
+	"role" : "Admin",
+	"email" : "admin2@test.com"
+}
+
+### 로그인 (일반 유저)
+# @name login
+POST http://localhost:3000/sign-in
+Content-Type: application/json
+
+{
+	"password" : "123456",
+	"email" : "customer1@test.com"
+}
+
+### 로그인 (어드민 유저)
+# @name login
+POST http://localhost:3000/sign-in
+Content-Type: application/json
+
+{
+	"password" : "123456",
+	"email" : "admin1@test.com"
+}
+
+### 예약하기
+POST http://localhost:3000/reservation/?performance=6
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "seatIds": [1,2,3],
+  "numbers": 4
+}
+
+### 특정 공연 모든 좌석 조회하기(performanceId)
+GET http://localhost:3000/seats/?performance=6
+
+### 특정 좌석 조회하기 (id)
+GET http://localhost:3000/seats/15
+
+### 특정 좌석 수정하기 (id)
+PATCH http://localhost:3000/seats/15
+Authorization: Bearer {{token}}
+
+### 특정 좌석 삭제하기 (id)
+DELETE http://localhost:3000/seats/13
+Authorization: Bearer {{token}}

--- a/api-docs/reservation.http
+++ b/api-docs/reservation.http
@@ -33,13 +33,13 @@ Content-Type: application/json
 }
 
 ### 예약하기
-POST http://localhost:3000/reservation/?performance=6
+POST http://localhost:3000/reservation/?performance=3
 Content-Type: application/json
 Authorization: Bearer {{token}}
 
 {
-  "seatIds": [1,2,3],
-  "numbers": 4
+  "seatIds": [18,19],
+  "numbers": 2
 }
 
 ### 특정 공연 모든 좌석 조회하기(performanceId)

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,8 @@ import { UsersModule } from './users/users.module';
 import { PerformancesModule } from './performances/performances.module';
 import { SeatsModule } from './seats/seats.module';
 import { Seat } from './seats/entities/seat.entity';
+import { ReservationModule } from './reservation/reservation.module';
+import { Reservation } from './reservation/entities/reservation.entity';
 
 const typeOrmModuleOptions = {
   useFactory: async (
@@ -24,7 +26,7 @@ const typeOrmModuleOptions = {
     username: configService.get('DB_USERNAME'),
     password: configService.get('DB_PASSWORD'),
     database: configService.get('DB_NAME'),
-    entities: [User, Performance, Seat],
+    entities: [User, Performance, Seat, Reservation],
     synchronize: configService.get('DB_SYNC'),
     logging: true,
   }),
@@ -49,6 +51,7 @@ const typeOrmModuleOptions = {
     SeatsModule,
     UsersModule,
     PerformancesModule,
+    ReservationModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/performances/entities/performance.entity.ts
+++ b/src/performances/entities/performance.entity.ts
@@ -1,4 +1,5 @@
 import { IsDate, IsString, IsNumber } from 'class-validator';
+import { Reservation } from 'src/reservation/entities/reservation.entity';
 import { Seat } from 'src/seats/entities/seat.entity';
 import { User } from 'src/users/entities/user.entity';
 import {
@@ -57,4 +58,7 @@ export class Performance {
 
   @OneToMany(() => Seat, (seat) => seat.performance)
   seat: Seat[];
+
+  @OneToMany(() => Reservation, (reservation) => reservation.performance)
+  reservation: Reservation[];
 }

--- a/src/performances/performances.controller.ts
+++ b/src/performances/performances.controller.ts
@@ -78,6 +78,7 @@ export class PerformancesController {
 
   /* 특정 공연 수정하기 */
   @UseGuards(RolesGuard)
+  @Roles(Role.Admin)
   @Patch(':id')
   async update(
     @Param('id') id: number,
@@ -93,6 +94,7 @@ export class PerformancesController {
   }
 
   @UseGuards(RolesGuard)
+  @Roles(Role.Admin)
   @Delete(':id')
   async remove(@Param('id') id: number, @UserInfo() user: User) {
     await this.performancesService.remove(id, user.id);

--- a/src/reservation/dto/create-reservation.dto.ts
+++ b/src/reservation/dto/create-reservation.dto.ts
@@ -1,7 +1,7 @@
 import { IsNotEmpty, IsNumber } from 'class-validator';
 
 export class CreateReservationDto {
-  @IsNumber()
+  @IsNumber({}, { each: true })
   @IsNotEmpty({ message: '좌석을 선택해주세요.' })
   readonly seatIds: number[];
 

--- a/src/reservation/dto/create-reservation.dto.ts
+++ b/src/reservation/dto/create-reservation.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class CreateReservationDto {
+  @IsNumber()
+  @IsNotEmpty({ message: '좌석을 선택해주세요.' })
+  readonly seatIds: number[];
+
+  @IsNumber()
+  @IsNotEmpty({ message: '인원수를 입력해주세요.' })
+  readonly numbers: number;
+}

--- a/src/reservation/dto/update-reservation.dto.ts
+++ b/src/reservation/dto/update-reservation.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateReservationDto } from './create-reservation.dto';
+
+export class UpdateReservationDto extends PartialType(CreateReservationDto) {}

--- a/src/reservation/entities/reservation-status.ts
+++ b/src/reservation/entities/reservation-status.ts
@@ -1,0 +1,5 @@
+export enum ReservationStatus {
+  Reserved = 'Reserved',
+  Cancled = 'Canceld',
+  Completed = 'Completed',
+}

--- a/src/reservation/entities/reservation.entity.ts
+++ b/src/reservation/entities/reservation.entity.ts
@@ -1,0 +1,68 @@
+import { IsEnum, IsNumber } from 'class-validator';
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ReservationStatus } from './reservation-status';
+import { User } from 'src/users/entities/user.entity';
+import { Performance } from 'src/performances/entities/performance.entity';
+import { Seat } from 'src/seats/entities/seat.entity';
+
+@Entity()
+export class Reservation {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @IsNumber()
+  @Column({ type: 'int', nullable: false })
+  userId: number;
+
+  @IsNumber()
+  @Column({ type: 'int', nullable: false })
+  performanceId: number;
+
+  @IsEnum(ReservationStatus)
+  @Column({
+    type: 'enum',
+    enum: ReservationStatus,
+    nullable: false,
+    default: ReservationStatus.Reserved,
+  })
+  status: ReservationStatus;
+
+  @IsNumber()
+  @Column({ type: 'int', nullable: false })
+  totalPrice: number;
+
+  @IsNumber()
+  @Column({ type: 'int', nullable: false })
+  numbers: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn({ default: null })
+  updatedAt?: Date;
+
+  @DeleteDateColumn({ default: null })
+  deletedAt?: Date;
+
+  @ManyToOne(() => User, (user) => user.reservation, {
+    onDelete: 'CASCADE',
+  })
+  user: User;
+
+  @ManyToOne(() => Performance, (performance) => performance.reservation, {
+    onDelete: 'CASCADE',
+  })
+  performance: Performance;
+
+  @OneToMany(() => Seat, (seat) => seat.user)
+  seat: Seat[];
+}

--- a/src/reservation/entities/reservation.entity.ts
+++ b/src/reservation/entities/reservation.entity.ts
@@ -63,6 +63,6 @@ export class Reservation {
   })
   performance: Performance;
 
-  @OneToMany(() => Seat, (seat) => seat.user)
+  @OneToMany(() => Seat, (seat) => seat.reservation)
   seat: Seat[];
 }

--- a/src/reservation/reservation.controller.spec.ts
+++ b/src/reservation/reservation.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReservationController } from './reservation.controller';
+import { ReservationService } from './reservation.service';
+
+describe('ReservationController', () => {
+  let controller: ReservationController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReservationController],
+      providers: [ReservationService],
+    }).compile();
+
+    controller = module.get<ReservationController>(ReservationController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { ReservationService } from './reservation.service';
+import { CreateReservationDto } from './dto/create-reservation.dto';
+import { UpdateReservationDto } from './dto/update-reservation.dto';
+
+@Controller('reservation')
+export class ReservationController {
+  constructor(private readonly reservationService: ReservationService) {}
+
+  @Post()
+  create(@Body() createReservationDto: CreateReservationDto) {
+    return this.reservationService.create(createReservationDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.reservationService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.reservationService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateReservationDto: UpdateReservationDto) {
+    return this.reservationService.update(+id, updateReservationDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.reservationService.remove(+id);
+  }
+}

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -34,32 +34,33 @@ export class ReservationController {
       performanceId,
       user.id,
     );
-
-    console.log('이거는 안나오나요?', reservation);
-
-    return reservation;
+    return {
+      success: 'true',
+      message: '예약에 성공했습니다.',
+      data: reservation,
+    };
   }
 
-  @Get()
-  findAll() {
-    return this.reservationService.findAll();
-  }
+  // @Get()
+  // findAll() {
+  //   return this.reservationService.findAll();
+  // }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.reservationService.findOne(+id);
-  }
+  // @Get(':id')
+  // findOne(@Param('id') id: string) {
+  //   return this.reservationService.findOne(+id);
+  // }
 
-  @Patch(':id')
-  update(
-    @Param('id') id: string,
-    @Body() updateReservationDto: UpdateReservationDto,
-  ) {
-    return this.reservationService.update(+id, updateReservationDto);
-  }
+  // @Patch(':id')
+  // update(
+  //   @Param('id') id: string,
+  //   @Body() updateReservationDto: UpdateReservationDto,
+  // ) {
+  //   return this.reservationService.update(+id, updateReservationDto);
+  // }
 
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.reservationService.remove(+id);
-  }
+  // @Delete(':id')
+  // remove(@Param('id') id: string) {
+  //   return this.reservationService.remove(+id);
+  // }
 }

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -1,15 +1,43 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  Query,
+} from '@nestjs/common';
 import { ReservationService } from './reservation.service';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 import { UpdateReservationDto } from './dto/update-reservation.dto';
+import { RolesGuard } from 'src/auth/guard/roles.guard';
+import { Role, User } from 'src/users/entities/user.entity';
+import { Roles } from 'src/utils/role.decorator';
+import { UserInfo } from 'src/utils/userInfo.decorator';
 
 @Controller('reservation')
 export class ReservationController {
   constructor(private readonly reservationService: ReservationService) {}
 
+  @UseGuards(RolesGuard)
+  @Roles(Role.Customer)
   @Post()
-  create(@Body() createReservationDto: CreateReservationDto) {
-    return this.reservationService.create(createReservationDto);
+  async create(
+    @Body() createReservationDto: CreateReservationDto,
+    @Query('performance') performanceId: number,
+    @UserInfo() user: User,
+  ) {
+    const reservation = await this.reservationService.create(
+      createReservationDto,
+      performanceId,
+      user.id,
+    );
+
+    console.log('이거는 안나오나요?', reservation);
+
+    return reservation;
   }
 
   @Get()
@@ -23,7 +51,10 @@ export class ReservationController {
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateReservationDto: UpdateReservationDto) {
+  update(
+    @Param('id') id: string,
+    @Body() updateReservationDto: UpdateReservationDto,
+  ) {
     return this.reservationService.update(+id, updateReservationDto);
   }
 

--- a/src/reservation/reservation.module.ts
+++ b/src/reservation/reservation.module.ts
@@ -3,10 +3,12 @@ import { ReservationService } from './reservation.service';
 import { ReservationController } from './reservation.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Reservation } from './entities/reservation.entity';
+import { SeatsModule } from 'src/seats/seats.module';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
   controllers: [ReservationController],
   providers: [ReservationService],
-  imports: [TypeOrmModule.forFeature([Reservation])],
+  imports: [TypeOrmModule.forFeature([Reservation]), SeatsModule, UsersModule],
 })
 export class ReservationModule {}

--- a/src/reservation/reservation.module.ts
+++ b/src/reservation/reservation.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ReservationService } from './reservation.service';
+import { ReservationController } from './reservation.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Reservation } from './entities/reservation.entity';
+
+@Module({
+  controllers: [ReservationController],
+  providers: [ReservationService],
+  imports: [TypeOrmModule.forFeature([Reservation])],
+})
+export class ReservationModule {}

--- a/src/reservation/reservation.service.spec.ts
+++ b/src/reservation/reservation.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReservationService } from './reservation.service';
+
+describe('ReservationService', () => {
+  let service: ReservationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ReservationService],
+    }).compile();
+
+    service = module.get<ReservationService>(ReservationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/reservation/reservation.service.ts
+++ b/src/reservation/reservation.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateReservationDto } from './dto/create-reservation.dto';
+import { UpdateReservationDto } from './dto/update-reservation.dto';
+
+@Injectable()
+export class ReservationService {
+  create(createReservationDto: CreateReservationDto) {
+    return 'This action adds a new reservation';
+  }
+
+  findAll() {
+    return `This action returns all reservation`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} reservation`;
+  }
+
+  update(id: number, updateReservationDto: UpdateReservationDto) {
+    return `This action updates a #${id} reservation`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} reservation`;
+  }
+}

--- a/src/reservation/reservation.service.ts
+++ b/src/reservation/reservation.service.ts
@@ -1,11 +1,104 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadGatewayException,
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 import { UpdateReservationDto } from './dto/update-reservation.dto';
+import { InjectEntityManager, InjectRepository } from '@nestjs/typeorm';
+import { Reservation } from './entities/reservation.entity';
+import { EntityManager, Repository } from 'typeorm';
+import { SeatsService } from 'src/seats/seats.service';
+import { SeatStatus } from 'src/seats/entities/seat-status';
+import { User } from 'src/users/entities/user.entity';
+import { Seat } from 'src/seats/entities/seat.entity';
+import { UsersService } from 'src/users/users.service';
 
 @Injectable()
 export class ReservationService {
-  create(createReservationDto: CreateReservationDto) {
-    return 'This action adds a new reservation';
+  constructor(
+    @InjectRepository(Reservation)
+    private readonly reservationRepository: Repository<Reservation>,
+    private readonly usersService: UsersService,
+    @InjectEntityManager()
+    private readonly entityManager: EntityManager,
+  ) {}
+
+  async create(
+    createReservationDto: CreateReservationDto,
+    performanceId: number,
+    userId: number,
+  ) {
+    const { seatIds, numbers } = createReservationDto;
+    if (seatIds.length !== numbers) {
+      throw new BadRequestException('인원수에 맞게 좌석을 선택해야 합니다.');
+    }
+
+    const reservation: Reservation = this.reservationRepository.create({
+      userId,
+      performanceId,
+      numbers,
+    });
+
+    /* 트랜잭션 시작 */
+    const newReservation = await this.entityManager.transaction(
+      'READ COMMITTED',
+      async (transactionEntityManager) => {
+        // 1. 좌석 상태값 변경 및 전체 금액 확인
+        let totalPrice = 0;
+        for (const seatId of seatIds) {
+          const seat = await transactionEntityManager.findOne(Seat, {
+            where: { id: seatId },
+          });
+          if (seat.status !== SeatStatus.Possible) {
+            throw new BadRequestException(
+              `${seat.zone}-${seat.seatNumber} 좌석은 이미 예약이 있습니다.`,
+            );
+          }
+
+          totalPrice += seat.price;
+
+          await transactionEntityManager.update(
+            Seat,
+            { id: seatId },
+            {
+              status: SeatStatus.Complete,
+              reservationId: reservation.id,
+            },
+          );
+        }
+
+        // 2. 예약 추가
+        reservation.totalPrice = totalPrice;
+        const newReservation = await transactionEntityManager.save(reservation);
+
+        // 3. 유저 포인트 차감
+        const user: User = await transactionEntityManager.findOne(User, {
+          where: { id: userId },
+        });
+
+        if (!user) {
+          throw new NotFoundException('예약하는 유저를 찾을 수 없습니다.');
+        }
+
+        const calculatePoint: number = user.point - totalPrice;
+
+        if (calculatePoint < 0) {
+          throw new BadGatewayException('보유하신 포인트가 부족합니다.');
+        }
+
+        await transactionEntityManager.update(
+          User,
+          { id: userId },
+          { point: calculatePoint },
+        );
+
+        return newReservation;
+      },
+    );
+
+    return newReservation;
   }
 
   findAll() {

--- a/src/seats/entities/seat.entity.ts
+++ b/src/seats/entities/seat.entity.ts
@@ -70,5 +70,5 @@ export class Seat {
   @ManyToOne(() => Reservation, (reservation) => reservation.seat, {
     onDelete: 'SET NULL',
   })
-  Reservation: Reservation;
+  reservation: Reservation;
 }

--- a/src/seats/entities/seat.entity.ts
+++ b/src/seats/entities/seat.entity.ts
@@ -30,10 +30,10 @@ export class Seat {
 
   @IsNumber()
   @Column({ type: 'int', nullable: true })
-  reservationId: number;
+  reservationId?: number;
 
   @IsString()
-  @Column({ type: 'string', nullable: false })
+  @Column({ type: 'varchar', nullable: false })
   zone: string;
 
   @IsNumber()
@@ -68,7 +68,7 @@ export class Seat {
   user: User;
 
   @ManyToOne(() => Reservation, (reservation) => reservation.seat, {
-    onDelete: 'DEFAULT',
+    onDelete: 'SET NULL',
   })
   Reservation: Reservation;
 }

--- a/src/seats/entities/seat.entity.ts
+++ b/src/seats/entities/seat.entity.ts
@@ -12,6 +12,7 @@ import { SeatStatus } from './seat-status';
 import { IsEnum, IsNumber, IsString } from 'class-validator';
 import { Performance } from 'src/performances/entities/performance.entity';
 import { User } from 'src/users/entities/user.entity';
+import { Reservation } from 'src/reservation/entities/reservation.entity';
 
 @Entity()
 @Unique(['zone', 'seatNumber', 'performanceId'])
@@ -20,23 +21,27 @@ export class Seat {
   id: number;
 
   @IsNumber()
-  @Column()
+  @Column({ type: 'int', nullable: false })
   performanceId: number;
 
   @IsNumber()
-  @Column()
+  @Column({ type: 'int', nullable: false })
   userId: number;
 
+  @IsNumber()
+  @Column({ type: 'int', nullable: true })
+  reservationId: number;
+
   @IsString()
-  @Column()
+  @Column({ type: 'string', nullable: false })
   zone: string;
 
   @IsNumber()
-  @Column()
+  @Column({ type: 'int', nullable: true })
   seatNumber: number;
 
   @IsNumber()
-  @Column()
+  @Column({ type: 'int', nullable: true })
   price: number;
 
   @IsEnum(SeatStatus)
@@ -61,4 +66,9 @@ export class Seat {
     onDelete: 'CASCADE',
   })
   user: User;
+
+  @ManyToOne(() => Reservation, (reservation) => reservation.seat, {
+    onDelete: 'DEFAULT',
+  })
+  Reservation: Reservation;
 }

--- a/src/seats/seats.controller.ts
+++ b/src/seats/seats.controller.ts
@@ -97,6 +97,7 @@ export class SeatsController {
 
   /* 좌석 삭제하기 */
   @UseGuards(RolesGuard)
+  @Roles(Role.Admin)
   @Delete(':id')
   async remove(@Param('id') id: number, @UserInfo() user: User) {
     await this.seatsService.remove(id, user.id);

--- a/src/seats/seats.module.ts
+++ b/src/seats/seats.module.ts
@@ -9,5 +9,6 @@ import { PerformancesModule } from 'src/performances/performances.module';
   controllers: [SeatsController],
   providers: [SeatsService],
   imports: [TypeOrmModule.forFeature([Seat]), PerformancesModule],
+  exports: [SeatsService],
 })
 export class SeatsModule {}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -10,6 +10,7 @@ import {
 } from 'typeorm';
 import { Performance } from 'src/performances/entities/performance.entity';
 import { Seat } from 'src/seats/entities/seat.entity';
+import { Reservation } from 'src/reservation/entities/reservation.entity';
 
 export enum Role {
   Admin = 'Admin',
@@ -54,4 +55,7 @@ export class User {
 
   @OneToMany(() => Seat, (seat) => seat.user)
   seat: Seat[];
+
+  @OneToMany(() => Reservation, (reservation) => reservation.user)
+  reservation: Reservation[];
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -9,5 +9,6 @@ import { User } from './entities/user.entity';
   controllers: [UsersController],
   providers: [UsersService, JwtService],
   imports: [TypeOrmModule.forFeature([User])],
+  exports: [UsersService],
 })
 export class UsersModule {}


### PR DESCRIPTION
#20 

**진행사항**
**1) 예약 기능 추가(트랜잭션 적용)**
- 예약 시 3개 쿼리 진행 필요 (예약 생성, 좌석 상태 수정, 유저 포인트 수정)
- 격리 수준 READ COMMITTED 설정 : 다른 트랜잭션이 커밋한 내용을 읽을 수 있게 한다. 
예약이 취소 되었을 경우 바로 적용할 수 있지 않을까? 생각함
-pessimistic_write 락을 설정하여 한번에 하나의 트랜잭션만 수정이 가능하도록 설정 (동시성 처리)

**특이사항**
**1) 조인 시 Seat 테이블과는 조인이 안되었던 문제**
- Seat 와 Reservation Entity파일에서 관계설정에 오류가 있었음 (오타)

**2) totalPrice와 reservationId**
- Seat테이블을 통해서 totalPrice를 구하고자 함
- Reservation 테이블에서는 totalPrice를 넣어야 예약이 생성됨
- Seat테이블에 reservationId 를 넣어야 조인이 가능함
- 즉, 서로를 참조하고 있어서 문제가 되는 상황 발생 !!
- **결과적으로 totalPrice를 별도로 구해주는 로직 추가하여 해결.. 더 좋은 방법이 없는지 ㅠㅠ**